### PR TITLE
[4.15] Retry in ProxyError during post inspector data

### DIFF
--- a/ironic_python_agent/tests/unit/test_inspector.py
+++ b/ironic_python_agent/tests/unit/test_inspector.py
@@ -204,6 +204,34 @@ class TestCallInspector(base.IronicAgentTest):
                           data, failures)
         self.assertEqual(5, mock_post.call_count)
 
+    @mock.patch.object(inspector, '_RETRY_WAIT', 0.01)
+    @mock.patch.object(inspector, '_RETRY_ATTEMPTS', 3)
+    def test_inspector_retries_on_50X_error(self, mock_post):
+        mock_post.side_effect = [mock.Mock(status_code=500),
+                                 mock.Mock(status_code=501),
+                                 mock.Mock(status_code=502)]
+        failures = utils.AccumulatedFailures()
+        data = collections.OrderedDict(data=42)
+        self.assertRaises(requests.exceptions.HTTPError,
+                          inspector.call_inspector,
+                          data, failures)
+        self.assertEqual(3, mock_post.call_count)
+
+    @mock.patch.object(inspector, '_RETRY_WAIT', 0.01)
+    @mock.patch.object(inspector, '_RETRY_ATTEMPTS', 2)
+    def test_inspector_retry_on_50X_and_succeed(self, mock_post):
+        mock_post.side_effect = [mock.Mock(status_code=503),
+                                 mock.Mock(status_code=200)]
+
+        failures = utils.AccumulatedFailures()
+        data = collections.OrderedDict(data=42)
+        inspector.call_inspector(data, failures)
+        self.assertEqual(2, mock_post.call_count)
+        mock_post.assert_called_with('url',
+                                     cert=None, verify=True,
+                                     data='{"data": 42, "error": null}',
+                                     timeout=30)
+
 
 class BaseDiscoverTest(base.IronicAgentTest):
     def setUp(self):

--- a/releasenotes/notes/inspector-retry-502-2b286e2ccc64c195.yaml
+++ b/releasenotes/notes/inspector-retry-502-2b286e2ccc64c195.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes the post data to inspector to retry in 50X errors.


### PR DESCRIPTION
* ProxyError is derived from ConnectionError, but it's necessary to check the Response object to identify.

- Added ProxyError in retry_if_exception_type
- Updated _post_to_inspector to proper handle ProxyError
- Updated the wait to use wait_exponential instead of wait_fixed.

Closes-Bug: 2045429
Change-Id: Iefe3fe581cd4e7c91a0da708e6f6d0fdaacab6fe