### PR TITLE
Call evaluate_hardware_support exactly once per hwm

### DIFF
--- a/ironic_python_agent/tests/unit/base.py
+++ b/ironic_python_agent/tests/unit/base.py
@@ -65,6 +65,7 @@ class IronicAgentTest(test_base.BaseTestCase):
 
         ext_base._EXT_MANAGER = None
         hardware._CACHED_HW_INFO = None
+        hardware._global_managers = None
 
     def _set_config(self):
         self.cfg_fixture = self.useFixture(config_fixture.Config(CONF))

--- a/ironic_python_agent/tests/unit/extensions/test_clean.py
+++ b/ironic_python_agent/tests/unit/extensions/test_clean.py
@@ -34,12 +34,14 @@ class TestCleanExtension(base.IronicAgentTest):
         }
         self.version = {'generic': '1', 'specific': '1'}
 
+    @mock.patch('ironic_python_agent.hardware.get_managers_detail',
+                autospec=True)
     @mock.patch('ironic_python_agent.hardware.get_current_versions',
                 autospec=True)
     @mock.patch('ironic_python_agent.hardware.dispatch_to_all_managers',
                 autospec=True)
     def test_get_clean_steps(self, mock_dispatch, mock_version,
-                             mock_cache_node):
+                             mock_managers, mock_cache_node):
         mock_version.return_value = self.version
 
         manager_steps = {
@@ -118,13 +120,17 @@ class TestCleanExtension(base.IronicAgentTest):
 
         }
 
-        hardware_support = {
-            'SpecificHardwareManager': 3,
-            'FirmwareHardwareManager': 4,
-            'DiskHardwareManager': 4
-        }
+        # NOTE(JayF): The real dict also has manager: hwm-object
+        #             but we don't use it in the code under test
+        hwms = [
+            {'name': 'SpecificHardwareManager', 'support': 3},
+            {'name': 'FirmwareHardwareManager', 'support': 4},
+            {'name': 'DiskHardwareManager', 'support': 4},
+        ]
 
-        mock_dispatch.side_effect = [manager_steps, hardware_support]
+        mock_dispatch.side_effect = [manager_steps]
+        mock_managers.return_value = hwms
+
         expected_return = {
             'hardware_manager_version': self.version,
             'clean_steps': expected_steps

--- a/ironic_python_agent/tests/unit/extensions/test_service.py
+++ b/ironic_python_agent/tests/unit/extensions/test_service.py
@@ -34,12 +34,14 @@ class TestServiceExtension(base.IronicAgentTest):
         }
         self.version = {'generic': '1', 'specific': '1'}
 
+    @mock.patch('ironic_python_agent.hardware.get_managers_detail',
+                autospec=True)
     @mock.patch('ironic_python_agent.hardware.get_current_versions',
                 autospec=True)
     @mock.patch('ironic_python_agent.hardware.dispatch_to_all_managers',
                 autospec=True)
     def test_get_service_steps(self, mock_dispatch, mock_version,
-                               mock_cache_node):
+                               mock_managers, mock_cache_node):
         mock_version.return_value = self.version
 
         manager_steps = {
@@ -118,13 +120,17 @@ class TestServiceExtension(base.IronicAgentTest):
 
         }
 
-        hardware_support = {
-            'SpecificHardwareManager': 3,
-            'FirmwareHardwareManager': 4,
-            'DiskHardwareManager': 4
-        }
+        # NOTE(JayF): The real dict also has manager: hwm-object
+        #             but we don't use it in the code under test
+        hwms = [
+            {'name': 'SpecificHardwareManager', 'support': 3},
+            {'name': 'FirmwareHardwareManager', 'support': 4},
+            {'name': 'DiskHardwareManager', 'support': 4},
+        ]
 
-        mock_dispatch.side_effect = [manager_steps, hardware_support]
+        mock_dispatch.side_effect = [manager_steps]
+        mock_managers.return_value = hwms
+
         expected_return = {
             'hardware_manager_version': self.version,
             'service_steps': expected_steps

--- a/ironic_python_agent/utils.py
+++ b/ironic_python_agent/utils.py
@@ -962,10 +962,10 @@ def _unmount_any_config_drives():
     and glean leverage a folder at /mnt/config to convey configuration
     to a booting OS.
 
-    The possibility exists that one of the utilties mounted one or multiple
+    The possibility exists that one of the utilities mounted one or multiple
     such folders, even if the configuration was not used, and this can
     result in locked devices which can prevent rebuild operations from
-    completing successfully as as long as the folder is mounted, it is
+    completing successfully as long as the folder is mounted, it is
     a "locked" device to the operating system.
     """
     while os.path.ismount('/mnt/config'):

--- a/releasenotes/notes/mix-and-match-disk-detection-58db04403ce220a0.yaml
+++ b/releasenotes/notes/mix-and-match-disk-detection-58db04403ce220a0.yaml
@@ -6,5 +6,5 @@ features:
     The new ``mix and match`` approach allows IPA to collect and match
     ``disk serial`` and ``wwn`` root device hints against values coming
     from both ``lsblk`` and ``udev`` at the same time. The ``mix and match``
-    approach is necesarry to handle edge cases where the serial and/or wwn
+    approach is necessary to handle edge cases where the serial and/or wwn
     information is different in ``lsblk`` compared to ``udev``.

--- a/releasenotes/notes/only-run-evaluate-hardware-support-once-9ec1ae327b4e03f2.yaml
+++ b/releasenotes/notes/only-run-evaluate-hardware-support-once-9ec1ae327b4e03f2.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes bug 2066308, an issue where Ironic Python Agent would call
+    evaluate_hardware_support multiple times on hardware manager plugins.
+    Scanning for hardware and disks is time consuming, and caused timeouts
+    on badly-performing nodes.

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,3 +70,4 @@ quiet-level = 4
 # Words to ignore:
 # cna: Intel CNA card
 ignore-words-list = cna
+skip = ./releasenotes/build,./venv,./doc/build


### PR DESCRIPTION
Fixes an issue where we could call evaluate_hardware_support multiple times each run. Now, instead, we cache the values and use the cache where needed.

Adds unit test coverage for get_managers and the new method. Fixes issue where we were caching hardware managers between unit tests.

Also includes fixes for codespell CI:
- skip build files in repo
- fix spelling issues introduced to repo

Closes-bug: 2066308
Change-Id: Iebc5b6d2440bfc9f23daa322493379bbe69e84d0