### PR TITLE
UPSTREAM: <carry>: pin upper-constraints

### DIFF
--- a/openstack-ipa-tester.Dockerfile
+++ b/openstack-ipa-tester.Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.16
 
+ENV TOX_CONSTRAINTS_FILE="https://releases.openstack.org/constraints/upper/2024.2"
+
 RUN dnf install -y python3-devel python3-pip \
  && dnf clean all \
  && rm -rf /var/cache/yum \


### PR DESCRIPTION
We need to pin libraries that are still compatible with python 3.9 as upstream has already dropped compatibility.

(cherry picked from commit 92eca43b52133261311b19d5c7fc2e7298159835)