### PR TITLE
OCPBUGS-62441: netutils: Use ethtool ioctl to get permanent mac address

### DIFF
--- a/ironic_python_agent/tests/unit/test_hardware.py
+++ b/ironic_python_agent/tests/unit/test_hardware.py
@@ -6279,6 +6279,7 @@ class TestCollectSystemLogs(base.IronicAgentTest):
 FakeAddr = namedtuple('FakeAddr', ('family', 'address'))
 
 
+@mock.patch.object(netutils, 'get_mac_addr', autospec=True)
 @mock.patch.object(hardware.GenericHardwareManager, '_get_system_lshw_dict',
                    autospec=True, return_value={'id': 'host'})
 @mock.patch.object(hardware, 'get_managers', autospec=True,
@@ -6303,7 +6304,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                      mocked_listdir,
                                      mocked_net_if_addrs,
                                      mockedget_managers,
-                                     mocked_lshw):
+                                     mocked_lshw,
+                                     mocked_get_mac_addr):
         mocked_lshw.return_value = json.loads(hws.LSHW_JSON_OUTPUT_V2[0])
         mocked_listdir.return_value = ['lo', 'eth0', 'foobar']
         mocked_exists.side_effect = [False, False, True, True]
@@ -6327,6 +6329,10 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                 FakeAddr(socket.AF_INET6, 'fd00:1000::101')
             ]
         }
+        mocked_get_mac_addr.side_effect = lambda iface: {
+            'lo': '00:00:00:00:00:00',
+            'eth0': '00:0c:29:8c:11:b1',
+        }.get(iface)
         mocked_execute.return_value = ('em0\n', '')
         mock_has_carrier.return_value = True
         interfaces = self.hardware.list_network_interfaces()
@@ -6348,7 +6354,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                                       mocked_listdir,
                                                       mocked_net_if_addrs,
                                                       mockedget_managers,
-                                                      mocked_lshw):
+                                                      mocked_lshw,
+                                                      mocked_get_mac_addr):
         mocked_listdir.return_value = ['lo', 'eth0']
         mocked_exists.side_effect = [False, False, True]
         mocked_open.return_value.__enter__ = lambda s: s
@@ -6367,6 +6374,10 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                 FakeAddr(socket.AF_PACKET, '00:0c:29:8c:11:b1')
             ]
         }
+        mocked_get_mac_addr.side_effect = lambda iface: {
+            'lo': '00:00:00:00:00:00',
+            'eth0': '00:0c:29:8c:11:b1',
+        }.get(iface)
         mocked_execute.return_value = ('em0\n', '')
         mock_has_carrier.return_value = True
         interfaces = self.hardware.list_network_interfaces()
@@ -6390,7 +6401,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                                mocked_listdir,
                                                mocked_net_if_addrs,
                                                mockedget_managers,
-                                               mocked_lshw):
+                                               mocked_lshw,
+                                               mocked_get_mac_addr):
         CONF.set_override('collect_lldp', True)
         mocked_listdir.return_value = ['lo', 'eth0']
         mocked_exists.side_effect = [False, False, True]
@@ -6410,6 +6422,10 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                 FakeAddr(socket.AF_PACKET, '00:0c:29:8c:11:b1')
             ]
         }
+        mocked_get_mac_addr.side_effect = lambda iface: {
+            'lo': '00:00:00:00:00:00',
+            'eth0': '00:0c:29:8c:11:b1',
+        }.get(iface)
         mocked_lldp_info.return_value = {'eth0': [
             (0, b''),
             (1, b'\x04\x88Z\x92\xecTY'),
@@ -6444,7 +6460,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                                      mocked_listdir,
                                                      mocked_net_if_addrs,
                                                      mockedget_managers,
-                                                     mocked_lshw):
+                                                     mocked_lshw,
+                                                     mocked_get_mac_addr):
         CONF.set_override('collect_lldp', True)
         mocked_listdir.return_value = ['lo', 'eth0']
         mocked_exists.side_effect = [False, False, True]
@@ -6464,6 +6481,10 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                 FakeAddr(socket.AF_PACKET, '00:0c:29:8c:11:b1')
             ]
         }
+        mocked_get_mac_addr.side_effect = lambda iface: {
+            'lo': '00:00:00:00:00:00',
+            'eth0': '00:0c:29:8c:11:b1',
+        }.get(iface)
         mocked_lldp_info.side_effect = Exception('Boom!')
         mocked_execute.return_value = ('em0\n', '')
         mock_has_carrier.return_value = True
@@ -6485,7 +6506,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                                 mocked_listdir,
                                                 mocked_net_if_addrs,
                                                 mockedget_managers,
-                                                mocked_lshw):
+                                                mocked_lshw,
+                                                mocked_get_mac_addr):
 
         mockedget_managers.return_value = [hardware.GenericHardwareManager()]
         mocked_listdir.return_value = ['lo', 'eth0']
@@ -6506,6 +6528,10 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                 FakeAddr(socket.AF_PACKET, '00:0c:29:8c:11:b1')
             ]
         }
+        mocked_get_mac_addr.side_effect = lambda iface: {
+            'lo': '00:00:00:00:00:00',
+            'eth0': '00:0c:29:8c:11:b1',
+        }.get(iface)
         mocked_execute.return_value = ('em0\n', '')
         mock_has_carrier.return_value = False
         interfaces = self.hardware.list_network_interfaces()
@@ -6526,7 +6552,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                                       mocked_listdir,
                                                       mocked_net_if_addrs,
                                                       mockedget_managers,
-                                                      mocked_lshw):
+                                                      mocked_lshw,
+                                                      mocked_get_mac_addr):
         mocked_listdir.return_value = ['lo', 'eth0']
         mocked_exists.side_effect = [False, False, True]
         mocked_open.return_value.__enter__ = lambda s: s
@@ -6546,6 +6573,10 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                 FakeAddr(socket.AF_PACKET, '00:0c:29:8c:11:b1')
             ]
         }
+        mocked_get_mac_addr.side_effect = lambda iface: {
+            'lo': '00:00:00:00:00:00',
+            'eth0': '00:0c:29:8c:11:b1',
+        }.get(iface)
         mocked_execute.return_value = ('em0\n', '')
         mock_has_carrier.return_value = True
         interfaces = self.hardware.list_network_interfaces()
@@ -6567,7 +6598,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                                mocked_listdir,
                                                mocked_net_if_addrs,
                                                mockedget_managers,
-                                               mocked_lshw):
+                                               mocked_lshw,
+                                               mocked_get_mac_addr):
         mocked_listdir.return_value = ['lo', 'bond0']
         mocked_exists.side_effect = [False, False, True]
         mocked_open.return_value.__enter__ = lambda s: s
@@ -6586,6 +6618,10 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                 FakeAddr(socket.AF_PACKET, '00:0c:29:8c:11:b1')
             ]
         }
+        mocked_get_mac_addr.side_effect = lambda iface: {
+            'lo': '00:00:00:00:00:00',
+            'bond0': '00:0c:29:8c:11:b1',
+        }.get(iface)
         mocked_execute.return_value = ('\n', '')
         mock_has_carrier.return_value = True
         interfaces = self.hardware.list_network_interfaces()
@@ -6610,7 +6646,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                                       mocked_listdir,
                                                       mocked_net_if_addrs,
                                                       mockedget_managers,
-                                                      mocked_lshw):
+                                                      mocked_lshw,
+                                                      mocked_get_mac_addr):
         mocked_listdir.return_value = ['lo', 'eth0']
         mocked_exists.side_effect = [False, False, True]
         mocked_open.return_value.__enter__ = lambda s: s
@@ -6629,6 +6666,10 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                 FakeAddr(socket.AF_PACKET, '00:0c:29:8c:11:b1')
             ]
         }
+        mocked_get_mac_addr.side_effect = lambda iface: {
+            'lo': '00:00:00:00:00:00',
+            'eth0': '00:0c:29:8c:11:b1',
+        }.get(iface)
         mocked_execute.return_value = ('em0\n', '')
         mock_has_carrier.return_value = True
         mock_get_pci.return_value = '0000:02:00.0'
@@ -6654,7 +6695,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                           mocked_listdir,
                                           mocked_net_if_addrs,
                                           mockedget_managers,
-                                          mocked_lshw):
+                                          mocked_lshw,
+                                          mocked_get_mac_addr):
         CONF.set_override('enable_vlan_interfaces', 'eth0.100')
         mocked_listdir.return_value = ['lo', 'eth0']
         mocked_exists.side_effect = [False, False, True]
@@ -6679,6 +6721,11 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                 FakeAddr(socket.AF_PACKET, '00:0c:29:8c:11:b1')
             ]
         }
+        mocked_get_mac_addr.side_effect = lambda iface: {
+            'lo': '00:00:00:00:00:00',
+            'eth0': '00:0c:29:8c:11:b1',
+            'eth0.100': '00:0c:29:8c:11:b1',
+        }.get(iface)
         mocked_execute.return_value = ('em0\n', '')
         mock_has_carrier.return_value = True
         interfaces = self.hardware.list_network_interfaces()
@@ -6702,7 +6749,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                                      mocked_listdir,
                                                      mocked_net_if_addrs,
                                                      mockedget_managers,
-                                                     mocked_lshw):
+                                                     mocked_lshw,
+                                                     mocked_get_mac_addr):
         CONF.set_override('collect_lldp', True)
         CONF.set_override('enable_vlan_interfaces', 'eth0')
         mocked_listdir.return_value = ['lo', 'eth0']
@@ -6734,6 +6782,12 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                 FakeAddr(socket.AF_PACKET, '00:0c:29:8c:11:c2')
             ]
         }
+        mocked_get_mac_addr.side_effect = lambda iface: {
+            'lo': '00:00:00:00:00:00',
+            'eth0': '00:0c:29:8c:11:b1',
+            'eth0.100': '00:0c:29:8c:11:c1',
+            'eth0.101': '00:0c:29:8c:11:c2',
+        }.get(iface)
         mocked_lldp_info.return_value = {'eth0': [
             (0, b''),
             (127, b'\x00\x80\xc2\x03\x00d\x08vlan-100'),
@@ -6767,7 +6821,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                            mocked_listdir,
                                            mocked_net_if_addrs,
                                            mockedget_managers,
-                                           mocked_lshw):
+                                           mocked_lshw,
+                                           mocked_get_mac_addr):
         CONF.set_override('collect_lldp', True)
         CONF.set_override('enable_vlan_interfaces', 'enp0s1')
         mocked_listdir.return_value = ['lo', 'eth0']
@@ -6805,7 +6860,8 @@ class TestListNetworkInterfaces(base.IronicAgentTest):
                                                          mocked_listdir,
                                                          mocked_net_if_addrs,
                                                          mockedget_managers,
-                                                         mocked_lshw):
+                                                         mocked_lshw,
+                                                         mocked_get_mac_addr):
         CONF.set_override('collect_lldp', True)
         CONF.set_override('enable_vlan_interfaces', 'all')
         mocked_listdir.return_value = ['lo', 'eth0', 'eth1']

--- a/releasenotes/notes/fix-mac-permaddr-0bc7d688eee4b814.yaml
+++ b/releasenotes/notes/fix-mac-permaddr-0bc7d688eee4b814.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixes IPA collecting the effective MAC address of NICs instead of the
+    pesistent MAC address. In case it fails to fetch the persistent address
+    falls back to effective MAC address.
+    See https://bugs.launchpad.net/ironic-python-agent/+bug/2103450 for
+    details.
+


### PR DESCRIPTION
Use ethtool ioctl to get permanent MAC address in ironic-python-agent so that in case of bonded interfaces, the correct interface MAC addresses are reported  
Backporting upstream fix into 4.19