### PR TITLE
[release-4.18] Add a flag to disable installing bootloaders

### DIFF
--- a/ironic_python_agent/agent.py
+++ b/ironic_python_agent/agent.py
@@ -508,6 +508,9 @@ class IronicPythonAgent(base.ExecuteCommandMixin):
 
         # Update config with values from Ironic
         config = content.get('config', {})
+        if config.get('enable_bios_bootloader_install'):
+            cfg.CONF.set_override('enable_bios_bootloader_install',
+                                  config['enable_bios_bootloader_install'])
         if config.get('metrics'):
             for opt, val in config.items():
                 setattr(cfg.CONF.metrics, opt, val)

--- a/ironic_python_agent/config.py
+++ b/ironic_python_agent/config.py
@@ -388,6 +388,13 @@ cli_opts = [
                      'image validation logic will fail the deployment '
                      'process. This check is skipped if deep image '
                      'inspection is disabled.'),
+    cfg.BoolOpt('enable_bios_bootloader_install',
+                default=False,
+                help='Enables support for partition images which require a '
+                     'legacy bootloader -- and a call to ``grub-install``. '
+                     'Generally, this should remain disabled for maximum '
+                     'security, however, this option allows it to be '
+                     're-enabled for compatibility.'),
 ]
 
 disk_utils_opts = [

--- a/ironic_python_agent/extensions/image.py
+++ b/ironic_python_agent/extensions/image.py
@@ -715,15 +715,24 @@ class ImageExtension(base.BaseAgentExtension):
                      ' Assuming a whole disk image')
             return
 
-        # In case we can't use efibootmgr for uefi we will continue using grub2
-        LOG.debug('Using grub2-install to set up boot files')
-        try:
-            _install_grub2(device,
-                           root_uuid=root_uuid,
-                           efi_system_part_uuid=efi_system_part_uuid,
-                           prep_boot_part_uuid=prep_boot_part_uuid,
-                           target_boot_mode=target_boot_mode)
-        except Exception as e:
-            LOG.error('Error setting up bootloader. Error %s', e)
+        if CONF.enable_bios_bootloader_install:
+            # In case we can't use efibootmgr for uefi we will continue
+            # using grub2
+            LOG.debug('Using grub2-install to set up boot files')
+            try:
+                _install_grub2(device,
+                               root_uuid=root_uuid,
+                               efi_system_part_uuid=efi_system_part_uuid,
+                               prep_boot_part_uuid=prep_boot_part_uuid,
+                               target_boot_mode=target_boot_mode)
+            except Exception as e:
+                LOG.error('Error setting up bootloader. Error %s', e)
+                if not ignore_failure:
+                    raise
+        else:
+            msg = ("Install of legacy BIOS bootloaders disabled by "
+                   "CONF.enable_bios_bootloader_install as part of "
+                   "CVE-2026-43003 mitigation.")
+            LOG.error(msg)
             if not ignore_failure:
-                raise
+                raise errors.InvalidImage(details=msg)

--- a/ironic_python_agent/tests/unit/extensions/test_image.py
+++ b/ironic_python_agent/tests/unit/extensions/test_image.py
@@ -52,6 +52,7 @@ class TestImageExtension(base.IronicAgentTest):
         self.fake_efi_system_part_uuid = '45AB-2312'
         self.fake_prep_boot_part_uuid = '76937797-3253-8843-999999999999'
         self.fake_dir = '/tmp/fake-dir'
+        self.config(enable_bios_bootloader_install=True)
 
     @mock.patch.object(image, '_install_grub2', autospec=True)
     def test__install_bootloader_bios(self, mock_grub2,
@@ -68,7 +69,38 @@ class TestImageExtension(base.IronicAgentTest):
             self.fake_dev, root_uuid=self.fake_root_uuid,
             efi_system_part_uuid=None, prep_boot_part_uuid=None,
             target_boot_mode='bios'
+
         )
+
+    @mock.patch.object(image, '_install_grub2', autospec=True)
+    def test__install_bootloader_bios_disabled(self, mock_grub2,
+                                               mock_execute, mock_dispatch):
+        self.config(enable_bios_bootloader_install=False)
+        mock_dispatch.side_effect = [
+            self.fake_dev, hardware.BootInfo(current_boot_mode='bios')
+        ]
+        self.agent_extension.install_bootloader(
+            root_uuid=self.fake_root_uuid).join()
+        mock_dispatch.assert_any_call('get_os_install_device')
+        mock_dispatch.assert_any_call('get_boot_info')
+        self.assertEqual(2, mock_dispatch.call_count)
+        mock_grub2.assert_not_called()
+
+    @mock.patch.object(image, '_install_grub2', autospec=True)
+    def test__install_bootloader_bios_disabled_dont_ignore_failures(
+            self, mock_grub2, mock_execute, mock_dispatch):
+        self.config(enable_bios_bootloader_install=False)
+        self.config(ignore_bootloader_failure=False)
+        mock_dispatch.side_effect = [
+            self.fake_dev, hardware.BootInfo(current_boot_mode='bios')
+        ]
+        result = self.agent_extension.install_bootloader(
+            root_uuid=self.fake_root_uuid).join()
+        mock_dispatch.assert_any_call('get_os_install_device')
+        mock_dispatch.assert_any_call('get_boot_info')
+        self.assertEqual(2, mock_dispatch.call_count)
+        self.assertIsNotNone(result.command_error)
+        mock_grub2.assert_not_called()
 
     @mock.patch.object(efi_utils, 'manage_uefi', autospec=True)
     @mock.patch.object(image, '_install_grub2', autospec=True)

--- a/releasenotes/notes/disable-installing-bootloaders-by-default-1029ed4faaf049aa.yaml
+++ b/releasenotes/notes/disable-installing-bootloaders-by-default-1029ed4faaf049aa.yaml
@@ -1,0 +1,9 @@
+---
+security:
+  - |
+    Disable installation of bootloaders (via grub-install) by default in order
+    to improve security posture by adding a new configuration option
+    `enable_bios_bootloader_install` which defaults to `False`. Operators
+    who still need this functionality can re-enable installation of
+    bootloaders by setting `enable_bios_bootloader_install` to `True`.
+    Addresses CVE-2026-43003.


### PR DESCRIPTION
Disables bootloader installations (calls to grub-install) for security reasons as part of the mitigation for CVE-2026-43003.

Depends-On: https://review.opendev.org/c/openstack/ironic/+/990724
Related-Bug: 2148310
Change-Id: I10c88426d5838820ecf6853dca5b3878dc29bdf4


(cherry picked from commit 6cd463a657edcddf7b79416ac69bdef5b6f30099) (cherry picked from commit c0eb9283312264d161590fd40bee724344a58f4b) (cherry picked from commit b0e864f653b093f5455a9124d7489e756dea9018) (cherry picked from commit 3b6cb96b84d1895a8b11835dabfd4622d9fa0a55) (cherry picked from commit 5b78e97aeeb1d28f3c340ce202b4a715bbb24f5b)